### PR TITLE
Pin keras version

### DIFF
--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -1,7 +1,7 @@
 appdirs==1.4.3
 h5py>=2.6.0
 imageio==2.5.0
-Keras>=2.3.1
+Keras==2.3.1
 numpy>=1.12.0
 packaging==16.8
 pyparsing==2.2.0

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -1,7 +1,7 @@
 appdirs==1.4.3
 h5py>=2.6.0
 imageio==2.5.0
-Keras>=2.3.1
+Keras==2.3.1
 numpy>=1.12.0
 packaging==16.8
 pyparsing==2.2.0


### PR DESCRIPTION
As our examples were created for Keras 2.3.1, recent upgrades to Keras (`keras>=2.3.1`) caused examples to break.

Before we update the examples, pin the Keras version to 2.3.1 so the examples work.